### PR TITLE
restored requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+python>=3
+pyqt>=5
+numpy
+numexpr
+scipy
+h5py
+gdal
+pillow
+cython
+matplotlib
+lxml
+scikit-image
+readline
+mako


### PR DESCRIPTION
With 1b2cc97, the `requirements.txt` has been removed, which breaks installation of PyRAT. This PR restores it.