### PR TITLE
Add CircleCI support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             source ~/miniconda/bin/activate
             conda env update -n base -f requirements.txt
             conda upgrade sip
-            sudo apt-get install libfftw3-dev
+            sudo apt-get install -y libfftw3-dev
             conda install -c conda-forge liblapack
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,54 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
+      - image: circleci/python:3.6.1
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "requirements.txt" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+            bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
+            source activate ~/miniconda
+            conda env update -n base -f requirements.txt
+
+      - build:
+          name: run build steps
+          command: |
+            source activate ~/miniconda
+            python setup.py build_ext --inplace
+            python setup.py install --user
+
+      - test:
+          name: import pyrat and run basic commands
+          command: |
+            source activate ~/miniconda
+            python -c "from pyrat import *"
+
+      - save_cache:
+          paths:
+            - ~/miniconda
+          key: v1-dependencies-{{ checksum "requirements.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,27 +19,15 @@ jobs:
 
     steps:
       - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
+      
       - run:
           name: install dependencies
           command: |
             wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-            bash Miniconda3-latest-Linux-x86_64.sh -b -p -u ~/miniconda
+            bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
             source ~/miniconda/bin/activate
             conda upgrade sip
             conda env update -n base -f requirements.txt
-
-      - save_cache:
-          paths:
-            - ~/miniconda
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
 
       - run:
           name: run build steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,15 +19,15 @@ jobs:
 
     steps:
       - checkout
-      
+
       - run:
           name: install dependencies
           command: |
             wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
             bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
             source ~/miniconda/bin/activate
-            conda upgrade sip
             conda env update -n base -f requirements.txt
+            conda upgrade sip
 
       - run:
           name: run build steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: install dependencies
           command: |
             wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-            bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
+            bash Miniconda3-latest-Linux-x86_64.sh -b -p -u ~/miniconda
             source ~/miniconda/bin/activate
             conda upgrade sip
             conda env update -n base -f requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             conda env update -n base -f requirements.txt
             conda upgrade sip
             sudo apt-get install -y libfftw3-dev
-            conda install -c conda-forge liblapack
+            conda install -y -c conda-forge liblapack
 
       - run:
           name: run build steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,14 +40,14 @@ jobs:
             - ~/miniconda
           key: v1-dependencies-{{ checksum "requirements.txt" }}
 
-      - build:
+      - run:
           name: run build steps
           command: |
             source activate ~/miniconda
             python setup.py build_ext --inplace
             python setup.py install --user
 
-      - test:
+      - run:
           name: import pyrat and run basic commands
           command: |
             source activate ~/miniconda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,8 @@ jobs:
             source ~/miniconda/bin/activate
             conda env update -n base -f requirements.txt
             conda upgrade sip
+            sudo apt-get install libfftw3-dev
+            conda install -c conda-forge liblapack
 
       - run:
           name: run build steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,11 @@ jobs:
             source activate ~/miniconda
             conda env update -n base -f requirements.txt
 
+      - save_cache:
+          paths:
+            - ~/miniconda
+          key: v1-dependencies-{{ checksum "requirements.txt" }}
+
       - build:
           name: run build steps
           command: |
@@ -47,8 +52,3 @@ jobs:
           command: |
             source activate ~/miniconda
             python -c "from pyrat import *"
-
-      - save_cache:
-          paths:
-            - ~/miniconda
-          key: v1-dependencies-{{ checksum "requirements.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: |
             wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
             bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
-            source activate ~/miniconda
+            source ~/miniconda/bin/activate
             conda env update -n base -f requirements.txt
 
       - save_cache:
@@ -43,12 +43,12 @@ jobs:
       - run:
           name: run build steps
           command: |
-            source activate ~/miniconda
+            source ~/miniconda/bin/activate
             python setup.py build_ext --inplace
             python setup.py install --user
 
       - run:
           name: import pyrat and run basic commands
           command: |
-            source activate ~/miniconda
+            source ~/miniconda/bin/activate
             python -c "from pyrat import *"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
             wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
             bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
             source ~/miniconda/bin/activate
+            conda upgrade sip
             conda env update -n base -f requirements.txt
 
       - save_cache:

--- a/pyrat/filter/Math.py
+++ b/pyrat/filter/Math.py
@@ -1,4 +1,4 @@
-aimport numexpr as ne
+import numexpr as ne
 import numpy as np
 import pyrat
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python>=3.5
-pyqt>=5
+pyqt==5.6.0
 numpy>=1.12
 numexpr
 scipy


### PR DESCRIPTION
This feature adds support for CircleCI and demonstrates installation on PyRAT on a clean debian based system using miniconda and some dependencies. The PR also involves pinning certain versions of PytQT5 for dependency consistency.