### PR TITLE
Add fftw to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ lxml
 scikit-image
 readline
 mako
+fftw


### PR DESCRIPTION
Add fftw to python requirements. It provides fftw3.h, needed to compile cython modules.